### PR TITLE
add metrika

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,0 +1,17 @@
+{
+    "structure": {
+        "readme": "ru/README.md"
+    },
+    "plugins": ["yametrika"],
+    "pluginsConfig": {
+        "yametrika": {
+            "id": 96561750,
+            "webvisor": true,
+            "clickmap": true,
+            "trackLinks": true,
+            "accurateTrackBounce": true,
+            "trackHash": true,
+            "ut": "noindex"
+        }
+    }
+}

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "instructions",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "node_modules/gitbook-plugin-yametrika": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/gitbook-plugin-yametrika/-/gitbook-plugin-yametrika-1.7.0.tgz",
+      "integrity": "sha512-mcjJDwVfS1HdY/wKJfGPlzOGqTePS9Bt873hqbSUzkQfm8jQPxSm2cwlFRoB4UJlVHR62wKmYAKH6e24NHltpw==",
+      "engines": {
+        "gitbook": ">=0.4.6"
+      }
+    }
+  }
+}

--- a/node_modules/gitbook-plugin-yametrika/README.md
+++ b/node_modules/gitbook-plugin-yametrika/README.md
@@ -1,0 +1,103 @@
+# Yandex Metrika tracker
+
+This is a best tracker from Russia! Enjoy it!
+
+### Install
+
+```
+$ npm install gitbook-plugin-yametrika
+```
+
+#### How to use it?
+
+Create your tracker in [Ya.Metrika](http://metrika.yandex.ru).
+
+Next you can use it for your book with in the book.json:
+
+``` json
+{
+    "plugins": ["yametrika"]
+}
+```
+
+You can set the Yandex Metrika tracking ID using the plugins configuration in the book.json:
+
+``` json
+{
+    "plugins": ["yametrika"],
+    "pluginsConfig": {
+        "yametrika": {
+            "number": 1111111
+        }
+    }
+}
+```
+
+You can customize the tracker object by passing additional configuration options.
+
+``` json
+{
+    "plugins": ["yametrika"],
+    "pluginsConfig": {
+        "yametrika": {
+            "number": 11111111,
+            "settings": {
+                "webvisor": true,
+                "clickmap": true,
+                "trackLinks": true,
+                "accurateTrackBounce": true,
+                "trackHash": true,
+                "ut": "noindex"
+            }
+        }
+    }
+}
+```
+
+When using GitBook 3, the whole configuration settings should be set directly in the `"yametrika"` property, using the default configuration for the API:
+``` json
+{
+    "plugins": ["yametrika"],
+    "pluginsConfig": {
+        "yametrika": {
+            "id": 11111111,
+            "webvisor": true,
+            "clickmap": true,
+            "trackLinks": true,
+            "accurateTrackBounce": true,
+            "trackHash": true,
+            "ut": "noindex"
+        }
+    }
+}
+```
+
+Available for customize options:
+- Webvisor (Вебвизор)
+- Clickmap (Карта кликов)
+- TrackLinks (Внешние ссылки, загрузки файлов и отчёт по кнопке «Поделиться»)
+- AccurateTrackBounce (Точный показатель отказов)
+- TrackHash (Отслеживание хеша в адресной строке)
+- Ut (Запрет на индексацию страниц)
+
+> ##### To use the option, you must specify it in the object "settings" with the status "true", if you do not want to use - just do not specify the object "settings"
+
+#### NOTICE
+
+default track options status:
+
+- Webvisor (Вебвизор) - **false** (!new)
+- Clickmap (Карта кликов) - **false** (!new)
+- TrackLinks (Внешние ссылки, загрузки файлов и отчёт по кнопке «Поделиться») - **false** (!new)
+- AccurateTrackBounce (Точный показатель отказов) - **false**  (!new)
+- Informer (Информер) - **false**
+- Ut (Запрет на индексацию страниц) - **false**
+- Async (Асинхронный код) - **true**
+- TrackHash (Отслеживание хеша в адресной строке) - **false**
+- XML (Для xml сайтов) - **false**
+- Params example - **false**
+- OneRow (Счетчик в одну строку) - **true**
+
+#### TO DO
+
+Include choose the *Informer*, *Async*, *XML*, *Params example*, *OneRow* options in book.json.

--- a/node_modules/gitbook-plugin-yametrika/_layouts/website/page.html
+++ b/node_modules/gitbook-plugin-yametrika/_layouts/website/page.html
@@ -1,0 +1,33 @@
+{% extends template.self %}
+
+{% block javascript %}
+    {{ super() }}
+    <script type='text/javascript'>
+        (function (d, w, c) {
+            (w[c] = w[c] || []).push(function() {
+                try {
+                    w.yaCounter{{ config.pluginsConfig.yametrika.id }} = new Ya.Metrika({{ config.pluginsConfig.yametrika|dump|safe }});
+                } catch(e) { }
+            });
+            var n = d.getElementsByTagName('script')[0],
+                s = d.createElement('script'),
+                f = function () {
+                    n.parentNode.insertBefore(s, n);
+                };
+
+            s.type = 'text/javascript';
+            s.async = true;
+            s.src = (d.location.protocol == 'https:' ? 'https:' : 'http:') + '//mc.yandex.ru/metrika/watch.js';
+            if (w.opera == '[object Opera]') {
+                d.addEventListener('DOMContentLoaded', f, false);
+            } else {
+                f();
+            }
+        })(document, window, 'yandex_metrika_callbacks');
+    </script>
+    <noscript>
+        <div>
+            <img src="//mc.yandex.ru/watch/{{ config.pluginsConfig.yametrika.id }}" style="position:absolute; left:-9999px;" alt=""/>
+        </div>
+    </noscript>
+{% endblock %}

--- a/node_modules/gitbook-plugin-yametrika/book/plugin.js
+++ b/node_modules/gitbook-plugin-yametrika/book/plugin.js
@@ -1,0 +1,13 @@
+require(["gitbook"], function(gitbook) {
+    gitbook.events.bind("start", function(e, config) {
+        config.yametrika = config.yametrika || {};
+    });
+
+    gitbook.events.bind("page.change", function() {
+      
+    });
+
+    gitbook.events.bind("exercise.submit", function(e, data) {
+
+    });
+});

--- a/node_modules/gitbook-plugin-yametrika/index.js
+++ b/node_modules/gitbook-plugin-yametrika/index.js
@@ -1,0 +1,8 @@
+module.exports = {
+    book: {
+        assets: "./book",
+        js: [
+            "plugin.js"
+        ]
+    }
+};

--- a/node_modules/gitbook-plugin-yametrika/package.json
+++ b/node_modules/gitbook-plugin-yametrika/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "gitbook-plugin-yametrika",
+  "description": "Yandex Metrika tracking for your gitbook",
+  "version": "1.7.0",
+  "main": "index.js",
+  "engines": {
+    "gitbook": ">=0.4.6"
+  },
+  "homepage": "https://github.com/mikaspell/gitbook-plugin-yametrika",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mikaspell/gitbook-plugin-yametrika.git"
+  },
+  "keywords": [
+    "gitbook",
+    "tracking",
+    "yandex",
+    "metrika"
+  ],
+  "author": "mikaspell",
+  "license": "MIT",
+  "gitbook": {
+    "properties": {
+      "id": {
+        "type": "number",
+        "description": "Yandex Metrika tracking ID",
+        "required": true
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "instructions",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "gitbook-plugin-yametrika": "^1.7.0"
+      }
+    },
+    "node_modules/gitbook-plugin-yametrika": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/gitbook-plugin-yametrika/-/gitbook-plugin-yametrika-1.7.0.tgz",
+      "integrity": "sha512-mcjJDwVfS1HdY/wKJfGPlzOGqTePS9Bt873hqbSUzkQfm8jQPxSm2cwlFRoB4UJlVHR62wKmYAKH6e24NHltpw==",
+      "engines": {
+        "gitbook": ">=0.4.6"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "gitbook-plugin-yametrika": "^1.7.0"
+  }
+}


### PR DESCRIPTION
не знаю, заработает ли так интеграция метрики. это всё что нашел по тому как добавить кастомный плагин.

для отслеживания конверсий в продвижении, чтобы ИИ Яндекса смог обучиться, надо добавить метрику яндекса, а у gitbook нет инструмента по добавлению кастомного html кода или этой метрики. тупо не добавили поддержку, добавили только google analytics.

если эти изменения не сработают и метрика не появится на страницах, откатим
